### PR TITLE
Restore squashfs support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Isolate NixOS QEMU VMs from each other and from the host by using a
-squashfs for the VM's /nix/store that contains only the VM's dependencies
+private /nix/store image that contains only the VM's dependencies
 (like the installer has) rather than a virtio mount of the host's entire
 /nix/store.
 

--- a/checks/mount-grep.nix
+++ b/checks/mount-grep.nix
@@ -18,16 +18,14 @@ pkgs: {
 
   testScript = ''
     start_all()
-    shared.wait_for_unit("multi-user.target")
-    private.wait_for_unit("multi-user.target")
-    useNixStoreImage.wait_for_unit("multi-user.target")
+    for machine in [shared, private, useNixStoreImage]:
+      machine.wait_for_unit("multi-user.target")
 
     shared.succeed("[[ $(mount | grep -c virt) -gt 0 ]]")
-    private.succeed("[[ $(mount | grep -c virt) -eq 0 ]]")
-    useNixStoreImage.succeed("[[ $(mount | grep -c virt) -eq 0 ]]")
-
     shared.succeed("[[ -e ${pkgs.pv} ]]")
-    private.fail("[[ -e ${pkgs.pv} ]]")
-    useNixStoreImage.fail("[[ -e ${pkgs.pv} ]]")
+
+    for machine in [private, useNixStoreImage]:
+      machine.succeed("[[ $(mount | grep -c virt) -eq 0 ]]")
+      machine.fail("[[ -e ${pkgs.pv} ]]")
   '';
 }

--- a/checks/mount-grep.nix
+++ b/checks/mount-grep.nix
@@ -12,6 +12,10 @@ pkgs: {
       imports = [ ../modules/qemu-vm-isolation.nix ];
       virtualisation.qemu.isolation.nixStoreFilesystemType = "erofs";
     };
+    privateSquash = _: {
+      imports = [ ../modules/qemu-vm-isolation.nix ];
+      virtualisation.qemu.isolation.nixStoreFilesystemType = "squashfs";
+    };
     useNixStoreImage = {
       virtualisation = {
         sharedDirectories = pkgs.lib.mkForce { };
@@ -22,13 +26,13 @@ pkgs: {
 
   testScript = ''
     start_all()
-    for machine in [shared, private, privateErofs, useNixStoreImage]:
+    for machine in [shared, private, privateErofs, privateSquash, useNixStoreImage]:
       machine.wait_for_unit("multi-user.target")
 
     shared.succeed("[[ $(mount | grep -c virt) -gt 0 ]]")
     shared.succeed("[[ -e ${pkgs.pv} ]]")
 
-    for machine in [private, privateErofs, useNixStoreImage]:
+    for machine in [private, privateErofs, privateSquash, useNixStoreImage]:
       machine.succeed("[[ $(mount | grep -c virt) -eq 0 ]]")
       machine.fail("[[ -e ${pkgs.pv} ]]")
   '';

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1686960236,
-        "narHash": "sha256-AYCC9rXNLpUWzD9hm+askOfpliLEC9kwAo7ITJc4HIw=",
+        "lastModified": 1689850295,
+        "narHash": "sha256-fUYf6WdQlhd2H+3aR8jST5dhFH1d0eE22aes8fNIfyk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04af42f3b31dba0ef742d254456dc4c14eedac86",
+        "rev": "5df4d78d54f7a34e9ea1f84a22b4fd9baebc68d0",
         "type": "github"
       },
       "original": {

--- a/modules/libblkid-squashfs-nix-store-kludge.patch
+++ b/modules/libblkid-squashfs-nix-store-kludge.patch
@@ -1,0 +1,19 @@
+# This dubious kludge results from
+# https://github.com/NixOS/nixpkgs/pull/236656 requiring filesystems to have labels and
+# https://github.com/plougher/squashfs-tools/issues/59 squashfs not supporting labels.
+diff --git a/libblkid/src/superblocks/squashfs.c b/libblkid/src/superblocks/squashfs.c
+index 4db842493..ed7465882 100644
+--- a/libblkid/src/superblocks/squashfs.c
++++ b/libblkid/src/superblocks/squashfs.c
+@@ -45,6 +45,11 @@ static int probe_squashfs(blkid_probe pr, const struct blkid_idmag *mag)
+ 
+ 	blkid_probe_sprintf_version(pr, "%u.%u", vermaj, vermin);
+ 
++	{
++		char label_kludge[] = "nix-store";
++		blkid_probe_set_label(pr, label_kludge, sizeof(label_kludge));
++	}
++
+ 	return 0;
+ }
+ 

--- a/modules/qemu-vm-isolation.nix
+++ b/modules/qemu-vm-isolation.nix
@@ -1,6 +1,10 @@
 { config, lib, modulesPath, pkgs, ... }:
 let
-  inherit (lib) findSingle mkForce mkIf mkMerge mkVMOverride;
+  inherit (lib)
+    escapeShellArg findSingle mkForce mkIf mkMerge mkOption mkVMOverride
+    optional;
+
+  cfg = config.virtualisation.qemu.isolation;
 
   lookupDriveDeviceName = driveName: driveList:
     (findSingle (drive: drive.name == driveName)
@@ -12,30 +16,15 @@ let
   else
     "/nix/store";
 
-in {
+  hostPkgs = config.virtualisation.host.pkgs;
 
-  fileSystems = mkVMOverride {
-    "${storeMountPath}" = {
-      device =
-        lookupDriveDeviceName "nixstore" config.virtualisation.qemu.drives;
-      fsType = "ext4";
-      options = [ "ro" ];
-      neededForBoot = true;
-    };
-  };
+  storeContents =
+    hostPkgs.closureInfo { rootPaths = config.virtualisation.additionalPaths; };
 
-  # We use this to disable fsck runs on the ext4 nix store image because stage-1
-  # fsck crashes (maybe because the device is read-only?), halting boot.
-  boot.initrd.checkJournalingFS = false;
-
-  system.build.nixStoreImage =
-    import (modulesPath + "/../lib/make-disk-image.nix") {
+  nixStoreImages = {
+    ext4 = import (modulesPath + "/../lib/make-disk-image.nix") {
       inherit pkgs config lib;
-      additionalPaths = [
-        (config.virtualisation.host.pkgs.closureInfo {
-          rootPaths = config.virtualisation.additionalPaths;
-        })
-      ];
+      additionalPaths = [ storeContents ];
       onlyNixStore = true;
       label = "nix-store";
       partitionTableType = "none";
@@ -44,20 +33,78 @@ in {
       additionalSpace = "0M";
       copyChannel = false;
     };
-
-  virtualisation = {
-
-    sharedDirectories = mkForce { };
-
-    qemu.drives = [{
-      name = "nixstore";
-      file = "${config.system.build.nixStoreImage}/nixos.img";
-      driveExtraOpts = {
-        format = "raw";
-        read-only = "on";
-        werror = "report";
-      };
-    }];
-
+    erofs = hostPkgs.runCommand "nix-store-image" { } ''
+      mkdir $out
+      cd ${builtins.storeDir}
+      ${hostPkgs.erofs-utils}/bin/mkfs.erofs \
+        --force-uid=0 \
+        --force-gid=0 \
+        -L nix-store \
+        -U eb176051-bd15-49b7-9e6b-462e0b467019 \
+        -T 0 \
+        --exclude-regex="$(
+          <${storeContents}/store-paths \
+            sed -e 's^.*/^^g' \
+          | cut -c -10 \
+          | ${hostPkgs.python3}/bin/python -c ${
+            escapeShellArg (builtins.readFile
+              (modulesPath + "/virtualisation/includes-to-excludes.py"))
+          } )" \
+        $out/nixos.img \
+        .
+    '';
   };
+
+in {
+  options = {
+    virtualisation.qemu.isolation.nixStoreFilesystemType = mkOption {
+      description = ''
+        What filesystem to use for the guest's Nix store.
+
+        erofs is more compact than ext4, but less mature.
+      '';
+      type = lib.types.enum [ "ext4" "erofs" ];
+      default = "ext4";
+    };
+  };
+  config = mkMerge [
+    {
+      boot.initrd.kernelModules =
+        optional (cfg.nixStoreFilesystemType == "erofs") "erofs";
+
+      fileSystems = mkVMOverride {
+        "${storeMountPath}" = {
+          device =
+            lookupDriveDeviceName "nixstore" config.virtualisation.qemu.drives;
+          fsType = cfg.nixStoreFilesystemType;
+          options = [ "ro" ];
+          neededForBoot = true;
+        };
+      };
+
+      system.build.nixStoreImage =
+        nixStoreImages."${cfg.nixStoreFilesystemType}";
+
+      virtualisation = {
+
+        sharedDirectories = mkForce { };
+
+        qemu.drives = [{
+          name = "nixstore";
+          file = "${config.system.build.nixStoreImage}/nixos.img";
+          driveExtraOpts = {
+            format = "raw";
+            read-only = "on";
+            werror = "report";
+          };
+        }];
+
+      };
+    }
+    (mkIf (cfg.nixStoreFilesystemType == "ext4") {
+      # We use this to disable fsck runs on the ext4 nix store image because stage-1
+      # fsck crashes (maybe because the device is read-only?), halting boot.
+      boot.initrd.checkJournalingFS = false;
+    })
+  ];
 }


### PR DESCRIPTION
Restore squashfs support with the dreadful kludge described in https://github.com/chkno/nixos-qemu-vm-isolation/issues/1#issuecomment-1645938910  that just hard-codes "nix-store" as the label for all squashfs filesystems.

Fixes #1